### PR TITLE
Add classes that look like they belong to hcommon-hive-metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBD
+## Added
+* MetastoreUnavailableException and MetaStoreUriNormaliser implementations.
+
 # [1.2.0] - 2018-09-21
 ### Added
 * MetastoreTunnel as a common class.

--- a/src/main/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableException.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hotels.hcommon.hive.metastore.exception;
 
 public class MetastoreUnavailableException extends RuntimeException {

--- a/src/main/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableException.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableException.java
@@ -1,0 +1,15 @@
+package com.hotels.hcommon.hive.metastore.exception;
+
+public class MetastoreUnavailableException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public MetastoreUnavailableException(String message) {
+    super(message);
+  }
+
+  public MetastoreUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/src/main/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliser.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliser.java
@@ -1,0 +1,28 @@
+package com.hotels.hcommon.hive.metastore.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.google.common.base.Joiner;
+
+public class MetaStoreUriNormaliser {
+
+  private MetaStoreUriNormaliser() {};
+
+  public static String normaliseMetaStoreUris(String metaStoreUris) {
+    try {
+      String[] rawUris = metaStoreUris.split(",");
+      Set<String> uris = new TreeSet<>();
+      for (String rawUri : rawUris) {
+        URI uri = new URI(rawUri);
+        uris.add(uri.toString());
+      }
+      return Joiner.on(",").join(uris);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/src/main/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliser.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliser.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hotels.hcommon.hive.metastore.util;
 
 import java.net.URI;

--- a/src/test/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableExceptionTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableExceptionTest.java
@@ -1,0 +1,28 @@
+package com.hotels.hcommon.hive.metastore.exception;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class MetastoreUnavailableExceptionTest {
+
+  private final String errorMessage = "error";
+
+  @Test
+  public void messageError() {
+    MetastoreUnavailableException exception = new MetastoreUnavailableException(errorMessage);
+    assertThat(exception.getMessage(), is(errorMessage));
+    assertNull(exception.getCause());
+  }
+
+  @Test
+  public void messageAndCauseError() {
+    Throwable cause = new Throwable();
+    MetastoreUnavailableException exception = new MetastoreUnavailableException(errorMessage, cause);
+    assertThat(exception.getMessage(), is(errorMessage));
+    assertThat(exception.getCause(), is(cause));
+  }
+
+}

--- a/src/test/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableExceptionTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/exception/MetastoreUnavailableExceptionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hotels.hcommon.hive.metastore.exception;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliserTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliserTest.java
@@ -1,0 +1,38 @@
+package com.hotels.hcommon.hive.metastore.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MetaStoreUriNormaliserTest {
+
+  @Test
+  public void normaliseValidUri() {
+    String uri = "thrift://localhost:1";
+
+    String normalisedUris = MetaStoreUriNormaliser.normaliseMetaStoreUris(uri);
+    assertEquals(uri, normalisedUris);
+  }
+
+  @Test
+  public void normaliseValidUris() {
+    String firstUri = "thrift://localhost:1";
+    String secondUri = "thrift://localhost:2";
+    String thirdUri = "thrift://localhost:3";
+
+    String uris = new StringBuilder(firstUri).append(",").append(secondUri).append(",").append(thirdUri).toString();
+    String normalisedUris = MetaStoreUriNormaliser.normaliseMetaStoreUris(uris);
+    assertEquals(uris, normalisedUris);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void normaliseInvalidUris() {
+    String firstUri = "thrift://localhost:1";
+    String secondUri = "thrift://localhost:2";
+    String thirdUri = "thrift://localh*;`#@32ost:3";
+
+    String uris = new StringBuilder(firstUri).append(",").append(secondUri).append(",").append(thirdUri).toString();
+    MetaStoreUriNormaliser.normaliseMetaStoreUris(uris);
+  }
+
+}

--- a/src/test/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliserTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/util/MetaStoreUriNormaliserTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hotels.hcommon.hive.metastore.util;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
These are moved from Waggle Dance because, based on what they do, they look like they belong here. However, Waggle Dance is the only project that uses these classes, so if you don't agree with moving these, I'm happy to put them back 🙂