### PR TITLE
Change name of method isStrictHostKeyChecking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# [1.2.3] - 2018-10-29
+### Fixed
+* Renamed function that indicates if strict host key checking is enabled to avoid causing a Spring Bean creation error.
+
 # [1.2.2] - 2018-10-23
 ### Added
-* Boolean function to indicate whether strict host key checking is set for MetastoreTunnel.
+* Boolean function to indicate whether strict host key checking is enabled for MetastoreTunnel.
 
 # [1.2.1] - 2018-10-15
 ### Changed

--- a/src/main/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnel.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnel.java
@@ -97,7 +97,7 @@ public class MetastoreTunnel {
     this.strictHostKeyChecking = strictHostKeyChecking;
   }
 
-  public boolean isStrictHostKeyChecking() {
+  public boolean getIsStrictHostKeyChecking() {
     return "yes".equalsIgnoreCase(strictHostKeyChecking);
   }
 }

--- a/src/main/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnel.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnel.java
@@ -97,7 +97,7 @@ public class MetastoreTunnel {
     this.strictHostKeyChecking = strictHostKeyChecking;
   }
 
-  public boolean getIsStrictHostKeyChecking() {
+  public boolean isStrictHostKeyCheckingEnabled() {
     return "yes".equalsIgnoreCase(strictHostKeyChecking);
   }
 }

--- a/src/test/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnelTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnelTest.java
@@ -202,12 +202,12 @@ public class MetastoreTunnelTest {
   @Test
   public void isStrictHostKeyCheckingForYes() {
     tunnel.setStrictHostKeyChecking("yes");
-    assertThat(tunnel.getIsStrictHostKeyChecking(), is(true));
+    assertThat(tunnel.isStrictHostKeyCheckingEnabled(), is(true));
   }
 
   @Test
   public void isStrictHostKeyCheckingForNo() {
     tunnel.setStrictHostKeyChecking("no");
-    assertThat(tunnel.getIsStrictHostKeyChecking(), is(false));
+    assertThat(tunnel.isStrictHostKeyCheckingEnabled(), is(false));
   }
 }

--- a/src/test/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnelTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/client/tunnelling/MetastoreTunnelTest.java
@@ -202,12 +202,12 @@ public class MetastoreTunnelTest {
   @Test
   public void isStrictHostKeyCheckingForYes() {
     tunnel.setStrictHostKeyChecking("yes");
-    assertThat(tunnel.isStrictHostKeyChecking(), is(true));
+    assertThat(tunnel.getIsStrictHostKeyChecking(), is(true));
   }
 
   @Test
   public void isStrictHostKeyCheckingForNo() {
     tunnel.setStrictHostKeyChecking("no");
-    assertThat(tunnel.isStrictHostKeyChecking(), is(false));
+    assertThat(tunnel.getIsStrictHostKeyChecking(), is(false));
   }
 }


### PR DESCRIPTION
Fixes the following exception from WaggleDance:

```
Caused by: org.yaml.snakeyaml.constructor.ConstructorException: Cannot create property=strict-host-key-checking for JavaBean=com.hotels.hcommon.hive.metastore.client.tunnelling.MetastoreTunnel@e25951c
 in 'reader', line 12, column 5:
        known-hosts: /home/hadoop/.ssh/k ...
        ^
No writable property 'strict-host-key-checking' on class: com.hotels.hcommon.hive.metastore.client.tunnelling.MetastoreTunnel
 in 'reader', line 17, column 31:
        strict-host-key-checking: 'yes'
                                  ^
```