### PR TITLE
Remove dependency on Java tools 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# TBD
+### Changed
+* Upgraded Hive version to 2.3.4 (was 2.3.2).
+* Removed transitive (provided) dependency on `hbase-client`.
+
 # [1.2.3] - 2018-10-29
 ### Fixed
 * Renamed function that indicates if strict host key checking is enabled to avoid causing a Spring Bean creation error.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -26,6 +27,7 @@
     <hibernate-validator.version>5.4.2.Final</hibernate-validator.version>
     <hive.version>2.3.4</hive.version>
     <javax-el.version>3.0.1-b08</javax-el.version>
+    <log4j2.version>2.6.2</log4j2.version>
     <mockito.version>1.10.19</mockito.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
   </properties>
@@ -55,26 +57,26 @@
       <artifactId>hcommon-ssh</artifactId>
       <version>${hcommon-ssh.version}</version>
     </dependency>
-    
+
     <!-- Hibernate for validation annotations -->
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>${hibernate-validator.version}</version>
-    </dependency> 
-    
+    </dependency>
+
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.el</artifactId>
       <version>${javax-el.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <version>${validation-api.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -86,6 +88,24 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -113,5 +133,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   </scm>
 
   <properties>
-    <beeju.version>1.2.1</beeju.version>
+    <beeju.version>1.3.0</beeju.version>
     <hamcrest-library.version>1.3</hamcrest-library.version>
     <hcommon-ssh.version>1.0.1</hcommon-ssh.version>
     <hibernate-validator.version>5.4.2.Final</hibernate-validator.version>
-    <hive.version>2.3.2</hive.version>
+    <hive.version>2.3.4</hive.version>
     <javax-el.version>3.0.1-b08</javax-el.version>
     <mockito.version>1.10.19</mockito.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
@@ -42,6 +42,12 @@
       <artifactId>hive-metastore</artifactId>
       <scope>provided</scope>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<Configuration>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %-5p %c:%L - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
- Upgraded Hive version to 2.3.4 (was 2.3.2)
- Removed transitive (provided) dependency on hbase-client
- Upgraded BeeJU to 1.3.0