### PR TITLE
Added compatibility for tableExists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [1.2.5] - 2019-02-21
-### Added
-* Hive 1.2 compatible `tableExists` method
+### Fixed
+* Added Hive 1.2 compatible `tableExists` method. See [#115](https://github.com/HotelsDotCom/circus-train/issues/115).
 
 # [1.2.4] - 2019-01-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [1.2.5] - 2019-02-21
+# [1.3.0] - 2019-02-27
 ### Fixed
 * Added Hive 1.2 compatible `tableExists` method. See [#115](https://github.com/HotelsDotCom/circus-train/issues/115).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.2.5] - 2019-02-21
+### Added
+* Hive 1.2 compatible `tableExists` method
+
 # [1.2.4] - 2019-01-10
 ### Changed
 * Refactored project to remove checkstyle and findbugs warnings, which does not impact functionality.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>hcommon-hive-metastore</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.0-SNAPSHOT</version>
   <inceptionYear>2018</inceptionYear>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>hcommon-hive-metastore</artifactId>
-  <version>1.2.5-SNAPSHOT</version>
+  <version>1.3.0</version>
   <inceptionYear>2018</inceptionYear>
 
   <scm>

--- a/src/main/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,4 +22,6 @@ import org.apache.thrift.TException;
 
 public interface HiveMetaStoreClientCompatibility {
   Table getTable(String dbname, String name) throws MetaException, TException, NoSuchObjectException;
+
+  boolean tableExists(String dbname, String name) throws MetaException, TException, NoSuchObjectException;
 }

--- a/src/main/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility12x.java
+++ b/src/main/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility12x.java
@@ -103,6 +103,16 @@ public class HiveMetaStoreClientCompatibility12x implements HiveMetaStoreClientC
     return deepCopy(get_table(dbname, name));
   }
 
+  @Override
+  public boolean tableExists(String dbname, String name) throws MetaException, TException, NoSuchObjectException {
+    try {
+      get_table(dbname, name);
+    } catch (NoSuchObjectException e) {
+      return false;
+    }
+    return true;
+  }
+
   /*
    * Copied from Hive 1.2.1 ThriftHiveMetastore.Client#get_table(String,String) - see
    * https://raw.githubusercontent.com/apache/hive/release-1.2.1/metastore/src/gen/thrift/gen-javabean/org/apache/hadoop

--- a/src/test/java/com/hotels/hcommon/hive/metastore/client/closeable/CloseableMetaStoreClientInvocationHandlerTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/client/closeable/CloseableMetaStoreClientInvocationHandlerTest.java
@@ -54,7 +54,7 @@ public class CloseableMetaStoreClientInvocationHandlerTest {
   }
 
   @Test
-  public void invokeCompatibilityWhenTApplicationExceptionIsThrown() throws Throwable {
+  public void invokeCompatibilityWhenGetTableTApplicationExceptionIsThrown() throws Throwable {
     Class<?> clazz = Class.forName(IMetaStoreClient.class.getName());
     Method method = clazz.getMethod("getTable", String.class, String.class);
     String dbName = "db";
@@ -70,6 +70,25 @@ public class CloseableMetaStoreClientInvocationHandlerTest {
     invocationHandler = new CloseableMetaStoreClientInvocationHandler(exceptionThrowingClient, compatibility);
     invocationHandler.invoke(null, method, new String[] { dbName, tableName });
     verify(compatibility).getTable(eq(dbName), eq(tableName));
+  }
+
+  @Test
+  public void invokeCompatibilityWhenTableExistsTApplicationExceptionIsThrown() throws Throwable {
+    Class<?> clazz = Class.forName(IMetaStoreClient.class.getName());
+    Method method = clazz.getMethod("tableExists", String.class, String.class);
+    String dbName = "db";
+    String tableName = "table";
+
+    IMetaStoreClient exceptionThrowingClient = Mockito.mock(IMetaStoreClient.class, new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        throw new TApplicationException();
+      }
+    });
+
+    invocationHandler = new CloseableMetaStoreClientInvocationHandler(exceptionThrowingClient, compatibility);
+    invocationHandler.invoke(null, method, new String[] { dbName, tableName });
+    verify(compatibility).tableExists(eq(dbName), eq(tableName));
   }
 
   @Test(expected = NoSuchObjectException.class)

--- a/src/test/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility12xTest.java
+++ b/src/test/java/com/hotels/hcommon/hive/metastore/compatibility/HiveMetaStoreClientCompatibility12xTest.java
@@ -15,8 +15,8 @@
  */
 package com.hotels.hcommon.hive.metastore.compatibility;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Fixes Circus Train [issue 115](https://github.com/HotelsDotCom/circus-train/issues/115).

When checking if a table exists in a metastore running an old version of Hive, an exception is thrown. This update adds a Hive 1.2 compatible `tableExists()` method to `HiveMetaStoreClientCompatibility`.

Having replicated the bug by running with a similar setup to the one described in the issue linked above, this seems to fix the problem.

Awaiting testing by the bug reporters before merging